### PR TITLE
Let Makefile work with MFA GH accounts and OSX mktemp.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,17 @@ BUILDDIR      = build
 
 # For auto gh-pages
 GH_PAGES_SOURCES = Makefile source 
-GH_DIR := $(shell mktemp -d)
-GH_URL = https://github.com/NSLS-II/NSLS-II.github.io.git
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+	GH_DIR := $(shell mktemp -dt foobar)
+else
+	GH_DIR := $(shell mktemp -d)
+endif
+ifeq ($(GIT_MF), 1)
+	GH_URL = git@github.com:NSLS-II/NSLS-II.github.io.git
+else
+	GH_URL = https://github.com/NSLS-II/NSLS-II.github.io.git
+endif
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)


### PR DESCRIPTION
I wrote this with @stuwilkins over my shoulder. For those like me who use `git@github.com:...` remotes, run

```
GH_MFA = 1 make github
```

Also, the Darwin variant of `mktemp` is used when needed.
