### PR TITLE
DOC: Add line to avoid nasty pip confusion.

### DIFF
--- a/source/install.rst
+++ b/source/install.rst
@@ -26,10 +26,11 @@ from the wired campus network or controls network.
     conda install binstar
     binstar config --set url https://conda.nsls2.bnl.gov/api
     conda config --add channels Nikea beamline
+    conda config --add create_default_packages pip
     conda update --all
 
-   Where ``beamline`` is the name of the beam-line organization you want to install source
-   for (see table at bottom)
+   Where ``beamline`` is the name of the beam-line organization you want to
+   install source for (in uppercase -- see the table at bottom)
 
 #. Install the collection or analysis stacks create a new environment ::
 


### PR DESCRIPTION
If pip is installed in a conda environment, system pip is (sliently) used. This can cause packages to leak into environments where they were not installed.

By making pip installed by default in _every_ environment, the issue is avoided. This PR adds that step to our suggested installation procedure.
