### PR TITLE
FIX: Add missing dot to .pyOlog.conf filename.

### DIFF
--- a/source/install.rst
+++ b/source/install.rst
@@ -17,7 +17,7 @@ Installation Procedure
 
 #. The following configuration files are touched by this procedure.
 
-     pyOlog.conf
+     .pyOlog.conf
      .condarc
      .config/
        binstar/


### PR DESCRIPTION
Minor but important edit to installation procedure.
