### PR TITLE
ENH: More examples

### DIFF
--- a/source/examples/archiver-appliance-integration.rst
+++ b/source/examples/archiver-appliance-integration.rst
@@ -1,0 +1,63 @@
+Access EPICS Archiver Appliance via the data broker
+***************************************************
+
+Problem
+=======
+
+Access all readings from a given PV during the duration of a run.
+
+Approach
+========
+
+Use the data broker's plugin mechanism.
+
+Example Solution
+================
+
+Configuration
+-------------
+
+This setup only has to be done once, typically in an IPython profile.
+
+Create an ``ArchiverPlugin``.
+
+.. code-block:: python
+
+    from datbroker import ArchiverPlugin
+    ARCHIVER_URL = 'http://xf16idc-ca.cs.nsls2.local:17668/'  # for example
+    ap = ArchiverPlugin(ARCHIVER_URL, 'US/Eastern')
+
+Then map the plugin to a custom keyword argument. We'll use ``archiver_pvs``
+for this example. Either customize an existing instance of ``Broker``,
+
+.. code-block:: python
+
+    from databroker import DataBroker as db  # singleton instance
+    db.plugins = {'archiver_pvs': ap}
+
+*or* create a new instance of ``Broker``.
+
+.. code-block:: python
+
+    import metadatastore.conf
+    from metadatastore.mds import MDSRO
+    mds = MDSRO(metadatastore.conf.connection_config)
+
+    import filestore.conf
+    from filestore.fs import FileStoreRO
+    fs = FileStoreRO(filestore.conf.connection_config)
+
+    db = Broker(mds, fs, plugins={'archiver_pvs': ap})
+
+Usage
+-----
+
+The configuration above adds a new, optional keyword argument to the data
+retrival methods, ``archiver_pvs``. They will query the Archiver Appliance for
+all readings for given PVs between the ``header['start']['time']`` and
+``header['stop']['time']``.
+
+.. code-block:: python
+
+    header = db[-1]
+    db.get_events(header, archiver_pvs=['...'])

--- a/source/examples/baseline-readings.rst
+++ b/source/examples/baseline-readings.rst
@@ -1,0 +1,57 @@
+Take baseline readings at the beginning and end
+***********************************************
+
+Problem
+=======
+
+Record the position or value of various motors or detectors at the beginning
+and end of a plan --- a snapshot of the state of the hardware.
+
+Approach
+========
+
+Customize a plan with the extra readings desired.
+
+Example Solution
+================
+
+.. code-block:: python
+
+    from bluesky.plans import baseline
+
+    plan = baseline(scan([det], motor, 1, 5, 5), [motor, det])
+
+If the same list of devices is often used, define a custom function bound to
+that specific list:
+
+.. code-block:: python
+
+    # only specify the devices once, here
+    my_baseline = partial(baseline, devices=[motor, det])
+
+    plan = my_baseline(scan[det], motor, 1, 5, 5))
+
+.. note:: 
+
+    In simple cases, using ``baseline`` is equivalent to sandwiching its
+    contents between two ``trigger_and_read`` plans.
+
+    .. code-block:: python
+
+        from bluesky.plans import pchain, trigger_and_read
+
+        plan = pchain(trigger_and_read([motor, det], name='baseline'),
+                    scan([det], motor, 1, 5, 5),
+                    trigger_and_read([motor, det], name='baseline'))
+
+    But if a plan involves multiple runs (multiple invocations of 'open_run'),
+    ``baseline`` inserts a fresh baseline reading at the beginning and end of
+    each run.
+
+An optional ``name`` parameter, which defaults to ``'baseline'``, is a label
+which makes it easy to retrieve this particular sequence of readings from the
+databroker:
+
+.. code-block:: python
+
+    db.get_table(header, name='baseline')

--- a/source/examples/concatenating-plans.rst
+++ b/source/examples/concatenating-plans.rst
@@ -1,0 +1,118 @@
+Concatenating plans
+*******************
+
+Problem
+=======
+
+Write a custom plan to run a multi-step procedure and/or collect data for
+more than one run.
+
+Approach
+========
+
+Bluesky provides several ways to combine plans. The choice depends on your
+use case and, to some extent, your personal taste.
+
+Example Solutions
+=================
+
+We will use some standard plans (scan, count), some stub plans (abs_set,
+sleep), and some plan utilities (pchain, and more later). See the
+`plans documentation in bluesky <https://nsls-ii.github.io/plans.html>`_ for
+more.
+
+.. code-block:: python
+
+    from bluesky.plans import pchain, scan, count, abs_set, sleep
+    from bluesky.examples import det, motor
+
+Simple chaining
+---------------
+
+The simplest approach is ``pchain`` (for "plan chain"). Examples:
+
+.. code-block:: python
+
+    # scan; sleep for 5 seconds; scan again with denser steps
+    pchain(scan([det], motor, 1, 5, 5),
+           sleep(5),
+           scan([det], motor, 1, 5, 10))
+
+    # scan; pause and wait for the user to resume; scan again
+    pchain(scan([det], motor, 1, 5, 5),
+           pause(),
+           scan([det], motor, 1, 5, 5))
+
+    # scan a motor; then move a different motor; then count
+    pchain(scan([det], motor, 1, 5, 5),
+           abs_set(motor2, 5),
+           count([det]))
+
+Controlling plans with arbitrary logic
+--------------------------------------
+
+Alternatively, plans can be combined by yielding from each plan in turn:
+
+.. code-block:: python
+
+    def scan_sleep_scan():
+        yield from scan([det], motor, 1, 5, 5)
+        yield from sleep(5)
+        yield from scan([det], motor, 1, 5, 10)
+
+This is (approximately) what ``pchain`` does. But this longer form gives us the
+opportunity to intercept the results from intermediate steps and use them
+to make plans responsive or adaptive. For example, we can query the user for
+input:
+
+.. code-block:: python
+
+    from plans import input  # note: this shadows the built-in function of the same name
+
+    def interactive_plan():
+        "Ask the user for a position. Move the motor there and count a detector."
+        pos = yield from input('where to?')
+        pos = float(pos)   # convert string input to number, e.g., '5' -> 5
+        yield from abs_set(motor, pos)
+        yield from count([det])
+
+We can also print to report progress, and we can include loops:
+
+.. code-block:: python
+
+    def loopy_plan():
+        for i in range(5):
+            print('iteration number', i)
+            yield from count([det])
+
+    # Note this is an illustrative example. In practice, for this specific
+    # case just use: count([det], num=5)
+
+Avoiding 'yield from' with a decorator
+--------------------------------------
+
+If the ``yield from`` seems forbidding, write a simple function that returns
+a list of plans, and top it with a decorator that takes care of the rest.
+
+This:
+
+.. code-block:: python
+
+    from bluesky.plans import planify
+
+    @planify
+    def scan_sleep_scan():
+        return [scan([det], motor, 1, 5, 5),
+                sleep(5),
+                scan([det], motor, 1, 5, 10)]
+
+is precisely equivalent to:
+
+.. code-block:: python
+
+    def scan_sleep_scan():
+        yield from scan([det], motor, 1, 5, 5)
+        yield from sleep(5)
+        yield from scan([det], motor, 1, 5, 10)
+
+You may use whichever pattern you find more readable.

--- a/source/examples/exporting-csv.rst
+++ b/source/examples/exporting-csv.rst
@@ -1,5 +1,5 @@
-Export Tabular Data as a CSV
-****************************
+Export tabular data as a CSV file
+*********************************
 
 Problem
 =======

--- a/source/examples/exporting-images.rst
+++ b/source/examples/exporting-images.rst
@@ -1,4 +1,4 @@
-Export Images as TIFF files
+Export images as TIFF files
 ***************************
 
 Problem

--- a/source/examples/fit-peaks.rst
+++ b/source/examples/fit-peaks.rst
@@ -1,4 +1,4 @@
-Fit and Analyze Peaks
+Fit and analyze peaks
 *********************
 
 Problem

--- a/source/examples/header-contents.rst
+++ b/source/examples/header-contents.rst
@@ -1,5 +1,5 @@
-Understand the contents of the header
-*************************************
+How metadata is organized: understand the contents of the header
+****************************************************************
 
 Problem
 =======

--- a/source/examples/index.rst
+++ b/source/examples/index.rst
@@ -22,10 +22,16 @@ These examples assume:
     simple-scan
     retrieving-data
     replot
+    pausing
+    concatenating-plans
     fit-peaks
     header-contents
     exporting-csv
     exporting-images
+    simulation-mode
+    baseline-readings
     adaptive-steps
     count-with-exp-decay-delay
     flyer-progress-bar
+    archiver-appliance-integration
+    msg-hook

--- a/source/examples/msg-hook.rst
+++ b/source/examples/msg-hook.rst
@@ -1,0 +1,51 @@
+Troubleshoot a slow or stalling plan
+************************************
+
+Problem
+=======
+
+A plan gets stuck or takes an unexpectedly long time to complete. We want to
+discover where the problem is.
+
+Approach
+========
+
+Print to the screen each time a new messsage from the plan in processed by the
+RunEngine. Then we will see the last message received before the plan freezes
+and/or slows.
+
+Example Solution
+================
+
+The RunEngine provides a special hook, a function that is calls every time it
+is about to process the next message in the plan.
+
+.. code-block:: python
+
+    RE.msg_hook = print
+
+Now the RunEngine will call ``print(msg)`` before processing each ``msg`` in
+the plan. Execute the plan that is causing the issue and watch the output.
+Suppose we are running a ``count`` that freezes up while triggering a detector.
+That would look like this:
+
+.. code-block:: python
+
+   In [7]: RE(count([det]))
+   stage: (<bluesky.examples.SynGauss object at 0x10f1bfb38>), (), {}
+   open_run: (None), (), {'plan_args': {'num': 1, 'detectors': ['<bluesky.examples.SynGauss object at 0x10f1bfb38>']}, 'detectors': ['det'], 'plan_name': 'count'}
+   checkpoint: (None), (), {}
+   trigger: (<bluesky.examples.SynGauss object at 0x10f1bfb38>), (), {'group': 'trigger-ff93f4'}
+   wait: (None), (), {'group': 'trigger-ff93f4'}
+
+The last message is is a 'wait' message, and it waiting for the 'trigger' just
+above it to complete. If the plan freezes at this point, a likely culprit is
+the triggering mechanism of the detector. In this example, we can see the
+detector in question is a simulated detector, ``bluesky.examples.SynGauss``.
+From here we would investigate whether the hardware was behaving properly and
+whether its triggering behavior was programmed properly on the Python side.
+
+When finished troubleshooting, set ``RE.msg_hook = None``.
+
+We used ``print`` for simple debugging. Any user-defined function that accepts
+a ``bluesky.Msg`` namedtuple as its argument could also be used.

--- a/source/examples/pausing.rst
+++ b/source/examples/pausing.rst
@@ -1,0 +1,39 @@
+Interruptions: interactively pause and resume
+*********************************************
+
+Problem
+=======
+
+Pause data collection interactively and then cleanly resume it.
+
+Approach
+========
+
+Execution can be paused interactively by pressing Ctrl+C.
+
+* Ctrl+C once: Pause at the next convenient stopping point.
+* Ctrl+C twice: Pause now, and roll back to the last convenient stopping point.
+
+To resume, call the ``resume`` method of the RunEngine instance, e.g.,
+
+.. code-block:: python
+
+    RE.resume()
+
+
+.. note::
+
+    The "global state RunEngine instance," ``gs.RE``, which is typically
+    aliased to ``RE``, includes a top-level function for terser resuming:
+
+    .. code-block:: python
+
+        # This is typically imported in the IPython profile.
+        from bluesky.global_state import resume
+
+        resume()  # an alias for gs.RE.resume()
+
+See the
+`relevant section of the bluesky documentation <https://nsls-ii.github.io/bluesky/state-machine.rst>`_
+for background on how pausing and resuming operates and how to customize its
+action.

--- a/source/examples/simulation-mode.rst
+++ b/source/examples/simulation-mode.rst
@@ -1,0 +1,63 @@
+Inspect or rehearse a plan without touching hardware ("simulation mode")
+************************************************************************
+
+Problem
+=======
+
+Check a plan for mistakes before running it on real hardware.
+
+Approach
+========
+
+1. Display the steps of a plan and read through them to verify that they match
+   our intention.
+2. Execute the plan on "simulated hardware," Python objects that stand in for
+   real motors and detectors but do not actually communicate with any hardware.
+
+Example Solutions
+=================
+
+The ``bluesky.examples`` module includes simulated motors and detectors.
+
+.. code-block:: python
+
+    # Import simulated motors and a detector.
+    from bluesky.examples import motor, motor1, motor2, det
+
+    # This may already be imported in the configuration.
+    from bluesky.plan_tools import print_summary
+    from bluesky.plans import count, scan, outer_product_scan
+
+.. ipython:: python
+    :suppress:
+
+    from bluesky.examples import motor, motor1, motor2, det
+    from bluesky.plan_tools import print_summary
+    from bluesky.plans import count, scan, outer_product_scan
+
+Inspect plans
+-------------
+
+Use ``print_summary`` which translates the plan into a human-readable list
+of steps.
+
+
+.. ipython:: python
+
+    print_summary(count([det]))
+    print_summary(scan([det], motor, 1, 3, 3))
+    print_summary(outer_product_scan([det], motor1, 1, 3, 3, motor2, 1, 2, 2, False))
+
+Note that ``print_summary`` cannot be used on plans the require feedback from
+the hardware, such as adaptively-spaced step scans.
+
+Rehearse plans
+--------------
+
+Simply execute the plan as usual --- ``RE(plan)`` --- but define that plan
+using the simulated motors and detectors from ``bluesky.examples`` instead of
+the variables that represent real hardware.
+
+.. code-block:: python
+
+    RE(count([det]))  # executes the plan, 'reading' the simulated detector

--- a/source/examples/simulation-mode.rst
+++ b/source/examples/simulation-mode.rst
@@ -61,3 +61,10 @@ the variables that represent real hardware.
 .. code-block:: python
 
     RE(count([det]))  # executes the plan, 'reading' the simulated detector
+
+To avoid saving data from these "rehearsal" runs, make a separate instance of
+the RunEngine, and do not subscribe metadatastore.
+
+.. code-block:: python
+
+    SIM_RE = RunEngine({})


### PR DESCRIPTION
New examples on:

pausing
concatenating plans: pchain, yield from, planify
"simulation mode" (print_summary and the use of dummy devices from bluesky.examples)
baseline readings
EPICS archiver appliance integration
troubleshooting a hung or slow plan with msg_hook
