### PR TITLE
DOC: add caproto docs link & remove unsupported docs links

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -134,6 +134,7 @@ The following projects are in use but in a less mature stage of development.
 
    bluesky <https://nsls-ii.github.io/bluesky>
    ophyd <https://nsls-ii.github.io/ophyd>
+   caproto <https://nsls-ii.github.io/caproto>
 
 .. toctree::
    :hidden:

--- a/source/index.rst
+++ b/source/index.rst
@@ -141,8 +141,6 @@ The following projects are in use but in a less mature stage of development.
    :caption: Data Access and Management
 
    databroker <https://nsls-ii.github.io/databroker>
-   amostra <https://nsls-ii.github.io/amostra>
-   datamuxer <https://nsls-ii.github.io/datamuxer>
    suitcase <https://nsls-ii.github.io/suitcase>
 
 .. toctree::


### PR DESCRIPTION
Closes #82 along with other projects' doc-PRs.