### PR TITLE
Updating the "installing on a personal computer" section 

### DIFF
--- a/source/fresh-installation.rst
+++ b/source/fresh-installation.rst
@@ -30,16 +30,16 @@ The configuration in ``/opt/conda/.condarc`` designates this location as the sec
 place conda should look for environments, after ``~/conda_envs``.
 
 Environments for data collection and data anlysis should be installed into
-``/opt/conda_envs``. In the second operating cycle of 2017, the commands to do
+``/opt/conda_envs``. In the second operating cycle of 2018, the commands to do
 this were:
 
 .. code-block:: bash
 
-    sudo conda create -p /opt/conda_envs/collection-17Q2.0 -c nsls2-tag -y collection
-    sudo conda create -p /opt/conda_envs/analysis-17Q2.0 -c nsls2-tag -y analysis
+    sudo conda create -p /opt/conda_envs/collection-2018-2.1 -c nsls2-tag -y collection
+    sudo conda create -p /opt/conda_envs/analysis-2018-2.1 -c nsls2-tag -y analysis
     fix_conda_privileges.sh
 
-where ``collection-17Q2.0`` and ``analysis-17Q2.0`` are the names of conda
+where ``collection-2018-2.1`` and ``analysis-2018-2.1`` are the names of conda
 metapackages and the names of the environments (under ``/opt/conda_envs``)
 where these metapackages are installed.
 
@@ -344,8 +344,30 @@ Installing on a Personal Computer
 ---------------------------------
 
 You can install these packages on your personal laptop outside the controls
-network. Install miniconda or Ananconda, and create user environment as
+network. Install miniconda or Anaconda, and create user environments as
 described above. All of the packages are mirrored on anaconda.org, outside of
 the NSLS-II firewall, where you will be able to access them. The channels are
 called ``lightsource2-tag`` and ``lightsource2-dev`` instead of ``nsls2-tag``
-and ``nsls2-dev`` respectively.
+and ``nsls2-dev`` respectively. The following serves as a step by step guide:
+
+1.  Follow the instructions in the link below to install minconda or anaconda.
+        https://conda.io/docs/user-guide/install/index.html
+
+2.  Open a terminal and run the following commands to install the enviroments. 
+
+.. code-block:: bash
+
+    sudo conda create -p /opt/conda_envs/collection-2018-2.1 -c lightsource2-tag -y collection
+    sudo conda create -p /opt/conda_envs/analysis-2018-2.1 -c lightsource2-tag -y analysis
+.. note::
+    1.  If you get the error 'The remote server could not find the noarch directory for the 
+        requested channel with url: https://conda.anaconda.org/nsls2-tag' then you are not on
+        the controls network, replace 'nsls2-tag' with 'lightsource2.tag' in the command.
+    2.  The 'collection-2018-2.1' or 'analysis-2018-2.1' part of these commands relates to the
+        released versions from the second cycle of 2018, to find the latest release versions 
+        visit 
+
+3. check this worked by running the command below:
+.. code-block:: bash
+    conda env list
+   you should see collection-2018-2.1 listed (or whichever version you installed)

--- a/source/fresh-installation.rst
+++ b/source/fresh-installation.rst
@@ -42,6 +42,10 @@ this were:
 where ``collection-2018-2.1`` and ``analysis-2018-2.1`` are the names of conda
 metapackages and the names of the environments (under ``/opt/conda_envs``)
 where these metapackages are installed.
+.. note::
+    FYI: The structure of the enviroment name version numbering is:
+        'year'-'version'-'mini version'
+    For example 2018-2.1 is version 2, mini-version 1 in 2018.  
 
 Install Scripts
 +++++++++++++++
@@ -350,25 +354,25 @@ the NSLS-II firewall, where you will be able to access them. The channels are
 called ``lightsource2-tag`` and ``lightsource2-dev`` instead of ``nsls2-tag``
 and ``nsls2-dev`` respectively. The following serves as a step by step guide:
 
-1.  Follow the instructions in the link below to install minconda or anaconda.
+#.  Follow the instructions in the link below to install minconda or anaconda.
         https://conda.io/docs/user-guide/install/index.html
 
-2.  Open a terminal and run the following commands to install the enviroments. 
+#.  Open a terminal and run the following commands to install the enviroments. 
 
-.. code-block:: bash
+    .. code-block:: bash
 
-    sudo conda create -p /opt/conda_envs/collection-2018-2.1 -c lightsource2-tag -y collection
-    sudo conda create -p /opt/conda_envs/analysis-2018-2.1 -c lightsource2-tag -y analysis
-.. note::
-    1.  If you get the error 'The remote server could not find the noarch directory for the 
-        requested channel with url: https://conda.anaconda.org/nsls2-tag' then you are not on
-        the controls network, replace 'nsls2-tag' with 'lightsource2-tag' in the command.
-        - ATTENTION: there is an existing 'lightsource' package but it is out of date, check that you
+        sudo conda create -p /opt/conda_envs/collection-2018-2.1 -c lightsource2-tag collection
+        sudo conda create -p /opt/conda_envs/analysis-2018-2.1 -c lightsource2-tag analysis
+    .. note::
+        1.  If you get the error 'The remote server could not find the noarch directory for the 
+            requested channel with url: https://conda.anaconda.org/nsls2-tag' then you are not on
+            the controls network, replace 'nsls2-tag' with 'lightsource2-tag' in the command.
+            - ATTENTION: there is an existing 'lightsource' package but it is out of date, check that you
                 are using the 'lightsource2-tag' package instead.
-    2.  The 'collection-2018-2.1' or 'analysis-2018-2.1' part of these commands relates to the
-        released versions from the second cycle of 2018, you can use any version here. 
+        2.  The 'collection-2018-2.1' or 'analysis-2018-2.1' part of these commands relates to the
+            released versions from the second cycle of 2018, you can use any version here. 
 
-3. check this worked by running the command below:
-.. code-block:: bash
-    conda env list
-   you should see collection-2018-2.1 listed (or whichever version you installed)
+#.  Check this worked by running the command below:
+    .. code-block:: bash
+        conda env list
+    You should see collection-2018-2.1 listed (or whichever version you installed).

--- a/source/fresh-installation.rst
+++ b/source/fresh-installation.rst
@@ -35,8 +35,8 @@ this were:
 
 .. code-block:: bash
 
-    sudo conda create -p collection-2018-2.1 -c nsls2-tag -y collection
-    sudo conda create -p analysis-2018-2.1 -c nsls2-tag -y analysis
+    sudo conda create -p /opt/conda_envs/collection-2018-2.1 -c nsls2-tag -y collection
+    sudo conda create -p /opt/conda_envs/analysis-2018-2.1 -c nsls2-tag -y analysis
     fix_conda_privileges.sh
 
 where ``collection-2018-2.1`` and ``analysis-2018-2.1`` are the names of conda
@@ -364,8 +364,8 @@ and ``nsls2-dev`` respectively. The following serves as a step by step guide:
 
     .. code-block:: bash
 
-        conda create -n /opt/conda_envs/collection-2018-2.1 -c lightsource2-tag collection
-        conda create -n /opt/conda_envs/analysis-2018-2.1 -c lightsource2-tag analysis
+        conda create -n collection-2018-2.1 -c lightsource2-tag collection
+        conda create -n analysis-2018-2.1 -c lightsource2-tag analysis
 
     .. note::
 

--- a/source/fresh-installation.rst
+++ b/source/fresh-installation.rst
@@ -362,10 +362,11 @@ and ``nsls2-dev`` respectively. The following serves as a step by step guide:
 .. note::
     1.  If you get the error 'The remote server could not find the noarch directory for the 
         requested channel with url: https://conda.anaconda.org/nsls2-tag' then you are not on
-        the controls network, replace 'nsls2-tag' with 'lightsource2.tag' in the command.
+        the controls network, replace 'nsls2-tag' with 'lightsource2-tag' in the command.
+        - ATTENTION: there is an existing 'lightsource' package but it is out of date, check that you
+                are using the 'lightsource2-tag' package instead.
     2.  The 'collection-2018-2.1' or 'analysis-2018-2.1' part of these commands relates to the
-        released versions from the second cycle of 2018, to find the latest release versions 
-        visit 
+        released versions from the second cycle of 2018, you can use any version here. 
 
 3. check this worked by running the command below:
 .. code-block:: bash

--- a/source/fresh-installation.rst
+++ b/source/fresh-installation.rst
@@ -42,10 +42,13 @@ this were:
 where ``collection-2018-2.1`` and ``analysis-2018-2.1`` are the names of conda
 metapackages and the names of the environments (under ``/opt/conda_envs``)
 where these metapackages are installed.
+
 .. note::
-    FYI: The structure of the enviroment name version numbering is:
-        'year'-'version'-'mini version'
-    For example 2018-2.1 is version 2, mini-version 1 in 2018.  
+
+   The structure of the enviroment name version numbering is
+   ``year-cycle.micro``. For example, in the second beam operating cycle of
+   2018, version ``2018-2.0`` was released, followed by ``2018-2.1`` with some
+   bug-fixes.
 
 Install Scripts
 +++++++++++++++
@@ -363,14 +366,27 @@ and ``nsls2-dev`` respectively. The following serves as a step by step guide:
 
         sudo conda create -p /opt/conda_envs/collection-2018-2.1 -c lightsource2-tag collection
         sudo conda create -p /opt/conda_envs/analysis-2018-2.1 -c lightsource2-tag analysis
+
     .. note::
-        1.  If you get the error 'The remote server could not find the noarch directory for the 
-            requested channel with url: https://conda.anaconda.org/nsls2-tag' then you are not on
-            the controls network, replace 'nsls2-tag' with 'lightsource2-tag' in the command.
-            - ATTENTION: there is an existing 'lightsource' package but it is out of date, check that you
-                are using the 'lightsource2-tag' package instead.
-        2.  The 'collection-2018-2.1' or 'analysis-2018-2.1' part of these commands relates to the
-            released versions from the second cycle of 2018, you can use any version here. 
+
+        If you get the error
+
+        .. code-block:: none
+
+           The remote server could not find the noarch directory for the requested channel with url: https://conda.anaconda.org/nsls2-tag'
+
+        then you are not on the controls network, replace ``nsls2-tag`` with
+        ``lightsource2-tag`` in the command.
+
+       The ``collection-2018-2.1`` or ``analysis-2018-2.1`` part of these
+       commands relates to the released versions from the second cycle of 2018;
+       you can use any version here.
+
+    .. warning::
+
+       There is a conda channel named ``lightsource2`` that it no longer
+       maintained. If you use it, you will find very old versions of some of
+       the packages used at NSLS-II. Use ``lightsource2-tag`` instead.
 
 #.  Check this worked by running the command below:
     .. code-block:: bash

--- a/source/fresh-installation.rst
+++ b/source/fresh-installation.rst
@@ -390,5 +390,6 @@ and ``nsls2-dev`` respectively. The following serves as a step by step guide:
 
 #.  Check this worked by running the command below:
     .. code-block:: bash
+
         conda env list
     You should see collection-2018-2.1 listed (or whichever version you installed).

--- a/source/fresh-installation.rst
+++ b/source/fresh-installation.rst
@@ -392,4 +392,5 @@ and ``nsls2-dev`` respectively. The following serves as a step by step guide:
     .. code-block:: bash
 
         conda env list
+
     You should see collection-2018-2.1 listed (or whichever version you installed).

--- a/source/fresh-installation.rst
+++ b/source/fresh-installation.rst
@@ -35,8 +35,8 @@ this were:
 
 .. code-block:: bash
 
-    sudo conda create -p /opt/conda_envs/collection-2018-2.1 -c nsls2-tag -y collection
-    sudo conda create -p /opt/conda_envs/analysis-2018-2.1 -c nsls2-tag -y analysis
+    sudo conda create -n collection-2018-2.1 -c nsls2-tag -y collection
+    sudo conda create -n analysis-2018-2.1 -c nsls2-tag -y analysis
     fix_conda_privileges.sh
 
 where ``collection-2018-2.1`` and ``analysis-2018-2.1`` are the names of conda

--- a/source/fresh-installation.rst
+++ b/source/fresh-installation.rst
@@ -35,8 +35,8 @@ this were:
 
 .. code-block:: bash
 
-    sudo conda create -n collection-2018-2.1 -c nsls2-tag -y collection
-    sudo conda create -n analysis-2018-2.1 -c nsls2-tag -y analysis
+    sudo conda create -p collection-2018-2.1 -c nsls2-tag -y collection
+    sudo conda create -p analysis-2018-2.1 -c nsls2-tag -y analysis
     fix_conda_privileges.sh
 
 where ``collection-2018-2.1`` and ``analysis-2018-2.1`` are the names of conda
@@ -364,8 +364,8 @@ and ``nsls2-dev`` respectively. The following serves as a step by step guide:
 
     .. code-block:: bash
 
-        sudo conda create -p /opt/conda_envs/collection-2018-2.1 -c lightsource2-tag collection
-        sudo conda create -p /opt/conda_envs/analysis-2018-2.1 -c lightsource2-tag analysis
+        conda create -n /opt/conda_envs/collection-2018-2.1 -c lightsource2-tag collection
+        conda create -n /opt/conda_envs/analysis-2018-2.1 -c lightsource2-tag analysis
 
     .. note::
 


### PR DESCRIPTION
This updates the section on 'installing on a personal computer' in fresh-installation.rst. I also updated the 'create conda enviroments' section above to point to the 2018-2.1 enviroments (as we changed the naming convention).