### PR TITLE
ENH: adding a warning and correcting a few typo/grammar issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ env:
 
 install:
   - pip install -q -r requirements.txt
-  - git clone https://github.com/tomopy/tomopy --branch master --single-branch ~/tomopy
-  - pushd ~/tomopy
-  - pip install -v .
-  - popd
+  - pip install git+https://github.com/tomopy/tomopy
   - ls -alF /home/travis/virtualenv/python3.6.3/lib/
   - export LD_LIBRARY_PATH="/home/travis/virtualenv/python3.6.3/lib/":$LD_LIBRARY_PATH
 

--- a/source/components/ansible-setup.rst
+++ b/source/components/ansible-setup.rst
@@ -59,6 +59,19 @@ Allan have access to it. Stash the password in file named
 You will also need sudo access on the hosts you want to change if that change
 requires privilege escalation.
 
+.. note::
+    The ``ansible-conda`` submodule should be copied locally using the
+    following command:
+
+    .. code-block:: bash
+        git submodule update --init --recursive
+.. note::
+    You should have a few files in the ``security`` directory, which
+    can be found on the jupyterhub server:
+    - ``cookie_secret``
+    - ``ssl.crt``
+    - ``ssl.key``
+
 Organization
 ============
 Inventories

--- a/source/components/ansible-setup.rst
+++ b/source/components/ansible-setup.rst
@@ -60,12 +60,16 @@ You will also need sudo access on the hosts you want to change if that change
 requires privilege escalation.
 
 .. note::
+
     The ``ansible-conda`` submodule should be copied locally using the
     following command:
 
     .. code-block:: bash
+
         git submodule update --init --recursive
+
 .. note::
+
     You should have a few files in the ``security`` directory, which
     can be found on the jupyterhub server:
     - ``cookie_secret``

--- a/source/components/ansible-setup.rst
+++ b/source/components/ansible-setup.rst
@@ -165,10 +165,10 @@ New databroker configuration
 Add a file to ``roles/databroker_config/files/`` and deploy the beamline
 playbook.
 
-.. note::
+.. warning::
 
-    BE CAREFUL: This will also update the databroker configuration file for ALL
-    conda enviroments, it may render the older enviroments unusable.
+    This will also update the databroker configuration file for ALL conda
+    enviroments, it may render the older enviroments unusable.
 
 
 New Environments

--- a/source/components/ansible-setup.rst
+++ b/source/components/ansible-setup.rst
@@ -97,7 +97,7 @@ The JupyterHub playbook configures a machine to run the JupyterHub process
 and single-user notebook server processes.
 
 Deploy it to the staging inventory first, which updates
-https://notedev.nsls2.bnl.gov.
+https://notebook-dev.nsls2.bnl.gov.
 
 .. code-block:: bash
 
@@ -164,6 +164,12 @@ New databroker configuration
 
 Add a file to ``roles/databroker_config/files/`` and deploy the beamline
 playbook.
+
+.. note::
+
+    BE CAREFUL: This will also update the databroker configuration file for ALL
+    conda enviroments, it may render the older enviroments unusable.
+
 
 New Environments
 ----------------

--- a/source/components/conda.rst
+++ b/source/components/conda.rst
@@ -5,12 +5,13 @@ Conda
 Conda Installation
 ==================
 
-We provide a system-wide installation of conda, which enables us to provide it
-to all users by default and to configure it in certain ways. Note that this is
+We use a system-wide installation of conda, which enables us to provide a
+default to all users and to configure it in certain ways. Note that this is
 different from how individuals usually work with conda, installing it into
 their home directories (``~/miniconda3``). We strongly advise users *not* to
 install conda on beamline machines, but to use the binary provided by us
-at ``/opt/conda/bin/conda``.
+at ``/opt/conda/bin/conda``. We advise this as it is the best way for us to
+provide useful support for conda issues.
 
 Conda Server
 ============

--- a/source/deployment/releasing-software.rst
+++ b/source/deployment/releasing-software.rst
@@ -27,7 +27,7 @@ Update NSLS-II Conda Recipes
 
 We keep conda recipes for our projects and external projects that we build in
 `NSLS-II/lightsource2-recipes <https://github.com/NSLS-II/lightsource2-recipes>`_.
-There are two copies of every recipes, one under the ``recipes-tag`` directory
+There are two copies of every recipe, one under the ``recipes-tag`` directory
 that is pinned to a specific tagged release, and one under the ``recipes-dev``
 directory that builds from the ``master`` branch.
 

--- a/source/deployment/resyncing-conda.rst
+++ b/source/deployment/resyncing-conda.rst
@@ -8,29 +8,35 @@ operating cycle, to help isolate users from changes that might break things
 mid-cycle due to some unintended upgrade.
 
 Before the start of each cycle, we re-synchronize our internal collection of
-packages with the latest packages available from Anaconda.
+packages with the latest packages available from Anaconda (defaults channel).
 
 The internal Anaconda server runs on the ``alexandria`` host, inside the Controls
-network, and it runs as a service account user ``anaconda-server``.
+network, and it runs as root.
 
 .. code-block:: bash
 
     ssh alexandria
-    sudo su anaconda-server
-    cd
-    export https_proxy=http://proxy:8888
-    export HTTPS_PROXY=http://proxy:8888
+    sudo su
+    bash /opt/builds/bootstrap-mirror-nsls2anaconda-local-folder
+    bash /opt/builds/run_conda_index
 
-The configuration file ``~/anaconda.yaml`` controls which packages are synced.
-Edit it, for example, to update which version(s) of Python we want packages for
-this cycle.
+bootstrap-mirror-nsls2anaconda-local-folder script can be easily written
+based on https://github.com/NSLS-II/lightsource2-recipes/blob/master/scripts/bootstrapping/bootstrap-tag-build and
+https://github.com/NSLS-II/lightsource2-recipes/blob/master/scripts/nsls2-tag-build-local.sh .
+Token needs to be provided in the script. conda_index needs to run every time
+new package is added. Information about conda index can also be found
+https://conda.io/docs/user-guide/tasks/create-custom-channels.html .
 
-Finally, the command to sync is:
+Moreover, sync of ``lightsouce2-tag`` to ``nsls2-tag`` is similar:
 
 .. code-block:: bash
 
-    /opt/continuum/anaconda_server/bin/anaconda-server-sync-conda --mirror-config anaconda.yaml | tee /tmp/update.txt
+    bash /opt/builds/bootstrap-mirror-nsls2tag-local-folder
 
-We have teed the log file into ``/tmp/update.txt``. Download that file using
-``scp`` and share it (e.g. in a Basecamp post) in case something goes wrong and
-we need to investigate later.
+We have teed the log file into, ``/root/tmp/mirror-logs/``,
+i.e, ``/root/tmp/mirror-logs/2019/01/03/14.25-mirror-nsls2-tag``.
+Download that file using ``scp`` and share it (e.g. in a Basecamp post)
+in case something goes wrong and we need to investigate later.
+
+This mirroring job for ``nsls2-tag`` is running at ``alexandria`` as a cronjob
+every 5 mins. conda_index is also included in cronjob for every 6 mins.

--- a/source/deployment/resyncing-conda.rst
+++ b/source/deployment/resyncing-conda.rst
@@ -10,19 +10,18 @@ mid-cycle due to some unintended upgrade.
 Before the start of each cycle, we re-synchronize our internal collection of
 packages with the latest packages available from Anaconda.
 
-The internal Anaconda server runs on the ``pergamon`` host, inside the Controls
-netowork, and it runs as a service account user ``anacodna-server``.
+The internal Anaconda server runs on the ``alexandria`` host, inside the Controls
+network, and it runs as a service account user ``anaconda-server``.
 
 .. code-block:: bash
 
-ssh pegramon
-sudo su anaconda-server
-cd
-export https_proxy=http://proxy:8888
-export HTTPS_PROXY=http://proxy:8888
+    ssh alexandria
+    sudo su anaconda-server cd export
+    https_proxy=http://proxy:8888 export
+    HTTPS_PROXY=http://proxy:8888
 
 The configuration file ``~/anaconda.yaml`` controls which packages are synced.
-Edit it to, for example, update which version(s) of Python we want packages for
+Edit it, for example, to update which version(s) of Python we want packages for
 this cycle.
 
 Finally, the command to sync is:

--- a/source/deployment/resyncing-conda.rst
+++ b/source/deployment/resyncing-conda.rst
@@ -8,7 +8,7 @@ operating cycle, to help isolate users from changes that might break things
 mid-cycle due to some unintended upgrade.
 
 Before the start of each cycle, we re-synchronize our internal collection of
-packages with the latest packages available from Anaconda (defaults channel).
+packages with the latest packages available from Anaconda (``defaults`` channel).
 
 The internal Anaconda server runs on the ``alexandria`` host, inside the Controls
 network, and it runs as root.
@@ -20,12 +20,12 @@ network, and it runs as root.
     bash /opt/builds/bootstrap-mirror-nsls2anaconda-local-folder
     bash /opt/builds/run_conda_index
 
-bootstrap-mirror-nsls2anaconda-local-folder script can be easily written
-based on https://github.com/NSLS-II/lightsource2-recipes/blob/master/scripts/bootstrapping/bootstrap-tag-build and
-https://github.com/NSLS-II/lightsource2-recipes/blob/master/scripts/nsls2-tag-build-local.sh .
-Token needs to be provided in the script. conda_index needs to run every time
-new package is added. Information about conda index can also be found
-https://conda.io/docs/user-guide/tasks/create-custom-channels.html .
+``bootstrap-mirror-nsls2anaconda-local-folder`` script can be easily written
+based on `bootstrap-tag-build <https://github.com/NSLS-II/lightsource2-recipes/blob/master/scripts/bootstrapping/bootstrap-tag-build>` and
+`nsls2-tag-build-local <https://github.com/NSLS-II/lightsource2-recipes/blob/master/scripts/nsls2-tag-build-local.sh>`_.
+Token needs to be provided in the script. ``conda index`` needs to run every time
+new package is added. Information about ``conda index`` can also be found at
+`create-custom-channels <https://conda.io/docs/user-guide/tasks/create-custom-channels.html>`_.
 
 Moreover, sync of ``lightsouce2-tag`` to ``nsls2-tag`` is similar:
 
@@ -39,4 +39,4 @@ Download that file using ``scp`` and share it (e.g. in a Basecamp post)
 in case something goes wrong and we need to investigate later.
 
 This mirroring job for ``nsls2-tag`` is running at ``alexandria`` as a cronjob
-every 5 mins. conda_index is also included in cronjob for every 6 mins.
+every 5 mins. ``conda index`` is also included in cronjob for every 6 mins.

--- a/source/deployment/resyncing-conda.rst
+++ b/source/deployment/resyncing-conda.rst
@@ -16,9 +16,10 @@ network, and it runs as a service account user ``anaconda-server``.
 .. code-block:: bash
 
     ssh alexandria
-    sudo su anaconda-server cd export
-    https_proxy=http://proxy:8888 export
-    HTTPS_PROXY=http://proxy:8888
+    sudo su anaconda-server
+    cd
+    export https_proxy=http://proxy:8888
+    export HTTPS_PROXY=http://proxy:8888
 
 The configuration file ``~/anaconda.yaml`` controls which packages are synced.
 Edit it, for example, to update which version(s) of Python we want packages for

--- a/source/deployment/resyncing-conda.rst
+++ b/source/deployment/resyncing-conda.rst
@@ -20,14 +20,20 @@ network, and it runs as root.
     bash /opt/builds/bootstrap-mirror-nsls2anaconda-local-folder
     bash /opt/builds/run_conda_index
 
-``bootstrap-mirror-nsls2anaconda-local-folder`` script can be easily written
-based on `bootstrap-tag-build <https://github.com/NSLS-II/lightsource2-recipes/blob/master/scripts/bootstrapping/bootstrap-tag-build>` and
+To modify which packages to synchronize, modify the script found in
+`bootstrap-tag-build <https://github.com/NSLS-II/lightsource2-recipes/blob/master/scripts/bootstrapping/bootstrap-tag-build>` and
 `nsls2-tag-build-local <https://github.com/NSLS-II/lightsource2-recipes/blob/master/scripts/nsls2-tag-build-local.sh>`_.
-Token needs to be provided in the script. ``conda index`` needs to run every time
-new package is added. Information about ``conda index`` can also be found at
-`create-custom-channels <https://conda.io/docs/user-guide/tasks/create-custom-channels.html>`_.
 
-Moreover, sync of ``lightsouce2-tag`` to ``nsls2-tag`` is similar:
+.. note::
+    ``bash /opt/builds/run_conda_index`` needs to run every time new package is
+    added. Information about ``conda index`` can also be found at
+    `create-custom-channels <https://conda.io/docs/user-guide/tasks/create-custom-channels.html>`_.
+
+.. note::
+    A Token needs to be provided in the script.
+    (`creating-access-tokens <https://docs.anaconda.com/anaconda-cloud/user-guide/tasks/work-with-accounts/#creating-access-tokens>`)
+
+Moreover, a sync of ``lightsouce2-tag`` to ``nsls2-tag`` follows a similar process:
 
 .. code-block:: bash
 
@@ -38,5 +44,5 @@ i.e, ``/root/tmp/mirror-logs/2019/01/03/14.25-mirror-nsls2-tag``.
 Download that file using ``scp`` and share it (e.g. in a Basecamp post)
 in case something goes wrong and we need to investigate later.
 
-This mirroring job for ``nsls2-tag`` is running at ``alexandria`` as a cronjob
-every 5 mins. ``conda index`` is also included in cronjob for every 6 mins.
+This mirroring job for ``nsls2-tag`` is running on ``alexandria`` as a cronjob
+every 5 mins. ``conda index`` is also included in a cronjob for every 6 mins.

--- a/source/deployment/updating-metapackages.rst
+++ b/source/deployment/updating-metapackages.rst
@@ -19,21 +19,22 @@ Overview
 ========
 
 We will update the requirements list in the **metapackages**, a human-friendly
-specification of our direct requirements. From the metapackages, we will
+specification of our direct requirements. From the metapackages we will
 generate **environment files**, an explicit, pinned specification of all the
-requirements, including indirect dependencies. The environment files will serve
+requirements including indirect dependencies. The environment files will serve
 as the canonical definition of software environments.
 
 Updating the Metapackages
 =========================
 
 #. Update the requirements listed in the ``analysis`` and ``collection``
-   metapacakges. Also update any beamline-specific metapackages if the
+   metapackages. Also update any beamline-specific metapackages if the
    beamlines' requirements have changed.
 
-#. Notice that certain requirement have minimum versions specified to ensure
+#. Notice that certain requirements have minimum versions specified to ensure
    that conda resolves the right version. We do this selectively (not on _all_
-   packages) to reduce the maintenace burden. Update these spefiers as needed.
+   packages) to reduce the maintenace burden. Update these specifiers as
+   needed.
 
 #. Finally, when you are ready to publish the new metapackages, submit a PR
    that bumps the version numbers in the recipes. The metapackages have the
@@ -51,7 +52,7 @@ We often discover a mistake in a metapackage shortly after publishing it. If
 the metapackage has already been deployed to beamlines, it should not be
 deleted; instead a new version should be released. But if we catch the error
 early, during deployment, we remove the bad metapackage and re-publish under
-the same version.
+the same version number.
 
 #. Delete the package from the public conda channel. Visit
    https://anaconda.org/lightsource2-tag/analysis/files and/or
@@ -113,7 +114,7 @@ Deploying the Environments
       scp <host>:~/collection-YYYY-X.V.yml .
 
 #. We typically keep the two newest environments in ``beamline_envs/files`` and
-   move anything other to ``beamline_envs/archived``. The old environments will
+   move anything else to ``beamline_envs/archived``. The old environments will
    thus not be deployed to new systems, but they remain easy to discover and
    reference.
 

--- a/source/deployment/upgrading-beamlines.rst
+++ b/source/deployment/upgrading-beamlines.rst
@@ -26,7 +26,8 @@ environment a given beamline is using remains accurate.
 
 In the ``production`` inventory file, located in the root directory of the
 NSLS-II/playbooks repository, find the beamline of interest and update its
-``curent_env_tag`` variable. Here is an excerpt:
+``curent_env_tag`` variable and then open a PR to NSLS-II/playbooks so that the
+change is recorded in the master branch. Here is an excerpt:
 
 .. code-block:: ini
 
@@ -35,9 +36,10 @@ NSLS-II/playbooks repository, find the beamline of interest and update its
    [02-ID-1:vars]
    current_env_tag="2018-3.0"
 
-Now deploy the change using the ``update_default_vars.yml`` playbook.
-Use ``--limit=XXX`` to target the playbook to the servers on the beamline of
-interest. This is important!
+Now deploy the change using the ``update_default_vars.yml`` playbook. Use
+``--limit=XXX`` to target the playbook to the servers on the beamline of
+interest. This is important! This step can occur prior to the PR opened above
+being merged, as it will use the local version of ``production``.
 
 .. code-block:: bash
 

--- a/source/deployment_docs.rst
+++ b/source/deployment_docs.rst
@@ -1,7 +1,7 @@
 NSLS-II Deployment Documentation
 ********************************
 
-This documentation describes how we deploying the "bluesky" software suite and
+This documentation describes how we deploy the "bluesky" software suite and
 associated configuration at NSLS-II. It is maintained as both an internal
 reference and a public guide for collaborators or potential collaborators who
 may be interested in our process.


### PR DESCRIPTION
This PR is a result of a review of the deployment docs section. It involves adding a warning based on an issue from the last cycle, a few grammar re-arrangments and correction of a few typos. I also updated the name of the local anaconda server to alexandria.