### PR TITLE
DEV: try to install tomopy from master using the new approach

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ install:
   - pip install -q -r requirements.txt
   - git clone https://github.com/tomopy/tomopy --branch master --single-branch ~/tomopy
   - pushd ~/tomopy
-  - python build.py
   - pip install -v .
   - popd
   - ls -alF /home/travis/virtualenv/python3.6.3/lib/

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ numexpr  # for gallery example
 numpy  # for gallery example
 numpydoc
 ophyd
+pandas  # for tomopy
 path.py
 pillow  # required by sphinx-gallery
 pyepics


### PR DESCRIPTION
I figured out the new way of installation of tomopy (currently the master branch, but will be released at some point). According to [tomopy's `INSTALL`](https://github.com/tomopy/tomopy/blob/e55da8699a7ff4793bee3fccec74a096f330497c/INSTALL#L8), it should just be `pip install .`