### PR TITLE
DOC: add links to all NSLS-II GH orgs

### DIFF
--- a/source/deployment_docs.rst
+++ b/source/deployment_docs.rst
@@ -24,6 +24,13 @@ Deployment Procedures
    deployment/updating-metapackages
    deployment/upgrading-beamlines
 
+NSLS-II GitHub organizations
+============================
+
+.. toctree::
+
+   gh-orgs-list
+
 Incident Reports
 ================
 

--- a/source/gh-orgs-list.rst
+++ b/source/gh-orgs-list.rst
@@ -2,31 +2,31 @@
 NSLS-II GitHub organizations
 ****************************
 
-* https://github.com/NSLS-II-AMX
-* https://github.com/NSLS-II-BMM
-* https://github.com/NSLS-II-CHX
-* https://github.com/NSLS-II-CMS
-* https://github.com/NSLS-II-CSX
-* https://github.com/NSLS-II-ESM
-* https://github.com/NSLS-II-FIS
-* https://github.com/NSLS-II-FMX
-* https://github.com/NSLS-II-FXI
-* https://github.com/NSLS-II-HXN
-* https://github.com/NSLS-II-IOS
-* https://github.com/NSLS-II-ISR
-* https://github.com/NSLS-II-ISS
-* https://github.com/NSLS-II-IXS
-* https://github.com/NSLS-II-LIX
-* https://github.com/NSLS-II-MET
-* https://github.com/NSLS-II-NYX
-* https://github.com/NSLS-II-PDF
-* https://github.com/NSLS-II-QAS
-* https://github.com/NSLS-II-SIX
-* https://github.com/NSLS-II-SMI
-* https://github.com/NSLS-II-SRX
-* https://github.com/NSLS-II-SST
-* https://github.com/NSLS-II-TES
-* https://github.com/NSLS-II-XFM
-* https://github.com/NSLS-II-XFP
-* https://github.com/NSLS-II-XPD
-* https://github.com/NSLS-II-XPDD
+* `NSLS-II-AMX <https://github.com/NSLS-II-AMX>`_
+* `NSLS-II-BMM <https://github.com/NSLS-II-BMM>`_
+* `NSLS-II-CHX <https://github.com/NSLS-II-CHX>`_
+* `NSLS-II-CMS <https://github.com/NSLS-II-CMS>`_
+* `NSLS-II-CSX <https://github.com/NSLS-II-CSX>`_
+* `NSLS-II-ESM <https://github.com/NSLS-II-ESM>`_
+* `NSLS-II-FIS <https://github.com/NSLS-II-FIS>`_
+* `NSLS-II-FMX <https://github.com/NSLS-II-FMX>`_
+* `NSLS-II-FXI <https://github.com/NSLS-II-FXI>`_
+* `NSLS-II-HXN <https://github.com/NSLS-II-HXN>`_
+* `NSLS-II-IOS <https://github.com/NSLS-II-IOS>`_
+* `NSLS-II-ISR <https://github.com/NSLS-II-ISR>`_
+* `NSLS-II-ISS <https://github.com/NSLS-II-ISS>`_
+* `NSLS-II-IXS <https://github.com/NSLS-II-IXS>`_
+* `NSLS-II-LIX <https://github.com/NSLS-II-LIX>`_
+* `NSLS-II-MET <https://github.com/NSLS-II-MET>`_
+* `NSLS-II-NYX <https://github.com/NSLS-II-NYX>`_
+* `NSLS-II-PDF <https://github.com/NSLS-II-PDF>`_
+* `NSLS-II-QAS <https://github.com/NSLS-II-QAS>`_
+* `NSLS-II-SIX <https://github.com/NSLS-II-SIX>`_
+* `NSLS-II-SMI <https://github.com/NSLS-II-SMI>`_
+* `NSLS-II-SRX <https://github.com/NSLS-II-SRX>`_
+* `NSLS-II-SST <https://github.com/NSLS-II-SST>`_
+* `NSLS-II-TES <https://github.com/NSLS-II-TES>`_
+* `NSLS-II-XFM <https://github.com/NSLS-II-XFM>`_
+* `NSLS-II-XFP <https://github.com/NSLS-II-XFP>`_
+* `NSLS-II-XPD <https://github.com/NSLS-II-XPD>`_
+* `NSLS-II-XPDD <https://github.com/NSLS-II-XPDD>`_

--- a/source/gh-orgs-list.rst
+++ b/source/gh-orgs-list.rst
@@ -1,0 +1,32 @@
+****************************
+NSLS-II GitHub organizations
+****************************
+
+* https://github.com/NSLS-II-AMX
+* https://github.com/NSLS-II-BMM
+* https://github.com/NSLS-II-CHX
+* https://github.com/NSLS-II-CMS
+* https://github.com/NSLS-II-CSX
+* https://github.com/NSLS-II-ESM
+* https://github.com/NSLS-II-FIS
+* https://github.com/NSLS-II-FMX
+* https://github.com/NSLS-II-FXI
+* https://github.com/NSLS-II-HXN
+* https://github.com/NSLS-II-IOS
+* https://github.com/NSLS-II-ISR
+* https://github.com/NSLS-II-ISS
+* https://github.com/NSLS-II-IXS
+* https://github.com/NSLS-II-LIX
+* https://github.com/NSLS-II-MET
+* https://github.com/NSLS-II-NYX
+* https://github.com/NSLS-II-PDF
+* https://github.com/NSLS-II-QAS
+* https://github.com/NSLS-II-SIX
+* https://github.com/NSLS-II-SMI
+* https://github.com/NSLS-II-SRX
+* https://github.com/NSLS-II-SST
+* https://github.com/NSLS-II-TES
+* https://github.com/NSLS-II-XFM
+* https://github.com/NSLS-II-XFP
+* https://github.com/NSLS-II-XPD
+* https://github.com/NSLS-II-XPDD


### PR DESCRIPTION
This was discussed a few times in Slack that it would be good to have some public place where we list all GH orgs. Here is an attempt to do so.