### PR TITLE
DOC: add git cheat sheet link + some clarifications

### DIFF
--- a/source/resources.rst
+++ b/source/resources.rst
@@ -29,6 +29,6 @@ Scientific Python Packages We Use
 Good Scientific Software Habits
 -------------------------------
 
-* `Git Cheat Sheet <http://nsls-ii.github.io/resources.html>`_
+* `Git Cheat Sheet <https://education.github.com/git-cheat-sheet-education.pdf>`_
 * `Novice-level introduction to Git from Software Carpentry <http://swcarpentry.github.io/git-novice>`_
 * `Intermediate-Level explanation of the git workflow we use <https://guides.github.com/introduction/flow/>`_

--- a/source/resources.rst
+++ b/source/resources.rst
@@ -3,7 +3,7 @@ Recommended Resources
 *********************
 
 For an in-depth introduction, we highly recommend
-`Python Scientific Lecture Notes <http://scipy-lectures.github.io/>`_.`
+`Python Scientific Lecture Notes <http://scipy-lectures.github.io/>`_.
 
 Books We Like
 -------------
@@ -29,5 +29,6 @@ Scientific Python Packages We Use
 Good Scientific Software Habits
 -------------------------------
 
-* `Novice-level introduction from Software Carpentry <http://swcarpentry.github.io/git-novice>`_
+* `Git Cheat Sheet <http://nsls-ii.github.io/resources.html>`_
+* `Novice-level introduction to Git from Software Carpentry <http://swcarpentry.github.io/git-novice>`_
 * `Intermediate-Level explanation of the git workflow we use <https://guides.github.com/introduction/flow/>`_


### PR DESCRIPTION
Updates:
- Remove a back-tick sign appearing at http://nsls-ii.github.io/resources.html.
- Add a link to the Git Cheat Sheet pdf.
- Clarify the link's description that it's for Git.