### PR TITLE
Add JPLS link to the list of GH orgs

### DIFF
--- a/source/gh-orgs-list.rst
+++ b/source/gh-orgs-list.rst
@@ -17,6 +17,7 @@ NSLS-II GitHub organizations
 * `NSLS-II-ISR <https://github.com/NSLS-II-ISR>`_
 * `NSLS-II-ISS <https://github.com/NSLS-II-ISS>`_
 * `NSLS-II-IXS <https://github.com/NSLS-II-IXS>`_
+* `NSLS-II-JPLS <https://github.com/NSLS-II-JPLS>`_
 * `NSLS-II-LIX <https://github.com/NSLS-II-LIX>`_
 * `NSLS-II-MET <https://github.com/NSLS-II-MET>`_
 * `NSLS-II-NYX <https://github.com/NSLS-II-NYX>`_


### PR DESCRIPTION
https://github.com/NSLS-II-JPLS link is missing from the list of NSLS-II GitHub organizations.

Am I missing any other new orgs?

By the way, all `profile_collection` repos can now be found by the GitHub topic `profile-collection`: https://github.com/topics/profile-collection.